### PR TITLE
updating docker compose file to provide default userame and password …

### DIFF
--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -1,11 +1,10 @@
-version: "3.8"
 services:
   postgres:
     image: postgres:14-alpine
     environment:
       POSTGRES_DB: assistantdb
-      POSTGRES_USER: youruser
-      POSTGRES_PASSWORD: yourpassword
+      POSTGRES_USER: db_user
+      POSTGRES_PASSWORD: db_user_password
     ports:
       - "5432:5432"
     volumes:


### PR DESCRIPTION
This pull request includes a small but important change to the `infrastructure/docker-compose.yml` file. The change updates the PostgreSQL user credentials to use more secure and appropriate values.

* [`infrastructure/docker-compose.yml`](diffhunk://#diff-f218f6ecb3c684187c2ac12188409e2e5af7f152b399c37e456d78fd7e7d9c10L1-R7): Updated the `POSTGRES_USER` and `POSTGRES_PASSWORD` environment variables to use `db_user` and `db_user_password` respectively.